### PR TITLE
fixed webhookHandler + tests for services added

### DIFF
--- a/kmaooad-functions/src/main/java/edu/kmaooad/webhook/TelegramWebhookHandler.java
+++ b/kmaooad-functions/src/main/java/edu/kmaooad/webhook/TelegramWebhookHandler.java
@@ -29,10 +29,7 @@ public class TelegramWebhookHandler extends FunctionInvoker<Update, BotApiMethod
                     authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<Optional<String>> request,
             final ExecutionContext context) {
-        System.out.println(request.toString());
-
         Update update;
-
         try {
             final String body = request.getBody().get();
 

--- a/kmaooad-functions/src/main/java/edu/kmaooad/webhook/TelegramWebhookHandler.java
+++ b/kmaooad-functions/src/main/java/edu/kmaooad/webhook/TelegramWebhookHandler.java
@@ -1,5 +1,6 @@
 package edu.kmaooad.webhook;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.functions.*;
 import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.functions.annotation.FunctionName;
@@ -28,8 +29,22 @@ public class TelegramWebhookHandler extends FunctionInvoker<Update, BotApiMethod
                     authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<Optional<String>> request,
             final ExecutionContext context) {
+        System.out.println(request.toString());
 
+        Update update;
 
-        return null;
+        try {
+            final String body = request.getBody().get();
+
+            final ObjectMapper mapper = new ObjectMapper();
+            update = mapper.readValue(body, Update.class);
+            handleRequest(update, context);
+        } catch (Exception exception) {
+            System.err.println(exception.getMessage());
+        }
+
+        return request
+                .createResponseBuilder(HttpStatus.OK)
+                .build();
     }
 }

--- a/kmaooad-functions/src/test/java/edu/kmaooad/services/ExpertServiceTest.java
+++ b/kmaooad-functions/src/test/java/edu/kmaooad/services/ExpertServiceTest.java
@@ -1,0 +1,36 @@
+package edu.kmaooad.services;
+
+import edu.kmaooad.models.Expert;
+import edu.kmaooad.repository.ExpertsRepository;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class ExpertServiceTest {
+
+    private final ExpertsRepository expertsRepository = mock(ExpertsRepository.class);
+    private final ExpertsService expertsService = new ExpertsServiceImpl(expertsRepository);
+
+    @Test
+    public void shouldCreateExpert() {
+        when(expertsRepository.save(any()))
+                .then(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        Expert expert = new Expert("email", "type", "name");
+        Expert result = expertsService.createExpert(expert);
+
+        assertEquals(expert, result);
+        verify(expertsRepository, times(1))
+                .save(expert);
+    }
+
+    @Test
+    public void shouldDeleteExpert() {
+        expertsService.deleteExpert(any());
+        verify(expertsRepository, times(1))
+                .delete(any());
+    }
+
+
+}

--- a/kmaooad-functions/src/test/java/edu/kmaooad/services/LocaleMessageServiceTest.java
+++ b/kmaooad-functions/src/test/java/edu/kmaooad/services/LocaleMessageServiceTest.java
@@ -1,0 +1,23 @@
+package edu.kmaooad.services;
+
+import org.junit.Test;
+import org.springframework.context.MessageSource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class LocaleMessageServiceTest {
+
+    private final MessageSource messageSource = mock(MessageSource.class);
+    private final LocaleMessageService localeMessageService = new LocaleMessageService("${localeTag}", messageSource);
+
+    @Test
+    public void shouldGetMessage() {
+        when(messageSource.getMessage(any(), any(), any()))
+                .then(invocationOnMock -> invocationOnMock.getArgument(0));
+        String message = "mess";
+        String result = localeMessageService.getMessage(message);
+        verify(messageSource, times(1))
+                .getMessage(any(), any(), any());
+    }
+
+}

--- a/kmaooad-functions/src/test/java/edu/kmaooad/services/SessionServiceTest.java
+++ b/kmaooad-functions/src/test/java/edu/kmaooad/services/SessionServiceTest.java
@@ -1,0 +1,35 @@
+package edu.kmaooad.services;
+
+import edu.kmaooad.models.Session;
+import edu.kmaooad.repository.SessionRepository;
+import org.junit.Test;
+import java.util.Optional;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class SessionServiceTest {
+
+    private final SessionRepository sessionRepository = mock(SessionRepository.class);
+    private final SessionService sessionService = new SessionServiceImpl(sessionRepository);
+
+    @Test
+    public void shouldReturnUser() {
+        when(sessionRepository.findById(any()))
+                .then(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        Optional<Session> session = sessionService.getSessionByUserId(any());
+        verify(sessionRepository, times(1))
+                .findById(any());
+    }
+
+    @Test
+    public void shouldCreateSession() throws Exception {
+        when(sessionRepository.save(any()))
+                .then(invocationOnMock -> invocationOnMock.getArgument(0));
+        Session session = sessionService.createSessionById(any());
+        verify(sessionRepository, times(1))
+                .save(any());
+    }
+
+
+}

--- a/kmaooad-functions/src/test/java/edu/kmaooad/services/TelegramServiceTest.java
+++ b/kmaooad-functions/src/test/java/edu/kmaooad/services/TelegramServiceTest.java
@@ -1,0 +1,23 @@
+package edu.kmaooad.services;
+
+import org.junit.Test;
+import static org.mockito.ArgumentMatchers.any;
+import edu.kmaooad.telegram.TelegramApi;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import static org.mockito.Mockito.*;
+
+public class TelegramServiceTest {
+
+    private final TelegramApi telegramApi = mock(TelegramApi.class);
+    private final LocaleMessageService localeMessageService = mock(LocaleMessageService.class);
+    private final TelegramService telegramService = new TelegramService(telegramApi, localeMessageService);
+
+    @Test
+    public void shouldSendMessage() throws TelegramApiException {
+        telegramService.sendMessage(0L, "hi there");
+        verify(telegramApi, times(1))
+                .execute(any(SendMessage.class));
+    }
+}


### PR DESCRIPTION
What's new:

- Made some fixes to telegramWebhookHandler so as to parse request body
- Added tests for all our services: ExpertsService, LocaleMessageService, TelegramService and SessionService